### PR TITLE
Replace Hyphen-minus by Minus Sign on minus button

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="button_equal">=</string>
     <string name="button_divide">÷</string>
     <string name="button_multiply">×</string>
-    <string name="button_subtract">-</string>
+    <string name="button_subtract">−</string>
     <string name="button_add">+</string>
 
     <string name="pref_notification">Notification settings</string>


### PR DESCRIPTION
In the main interface, the minus button should displaying Unicode minus sign (U+2212) for consistency on screen.
See: https://en.wikipedia.org/wiki/Hyphen-minus